### PR TITLE
fix: add yamllint config

### DIFF
--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -2,6 +2,7 @@
 name: 'yamllinting'
 
 on:
+  - push
   - pull_request
 
 jobs:

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,7 @@
+---
+
+extends: default
+
+rules:
+  line-length: disable
+  truthy: disable


### PR DESCRIPTION
## Description

* Yamllint should run on each push to give instant feedback if a commit is bad.

* Yamllint is failing because of missing config adjustments. 
