### PR TITLE
feat(runtype): add firstboot runtype to playbook.yml

### DIFF
--- a/potos-iso/contrib/scripts/finish.sh
+++ b/potos-iso/contrib/scripts/finish.sh
@@ -49,10 +49,10 @@ fi
 cd "${ANSIBLE_WORKDIR}"
 if [[ ${POTOS_ENV} == develop ]]; then
   ansible-playbook prepare.yml -vvv | sed -u 's/^/# /'
-  ansible-playbook playbook.yml -vvv | sed -u 's/^/# /'
+  ansible-playbook playbook.yml -vvv -e potos_runtype="firstboot" | sed -u 's/^/# /'
 else
   ansible-playbook prepare.yml | sed -u 's/^/# /'
-  ansible-playbook playbook.yml | sed -u 's/^/# /'
+  ansible-playbook playbook.yml -e potos_runtype="firstboot" | sed -u 's/^/# /'
 fi
 
 ################################################################################


### PR DESCRIPTION
`-e potos_runtype="firstboot"` is required to run the ready2use [firstboot role](https://github.com/projectpotos/ansible-role-potos_firstboot) from [ansible-specs-potos](https://github.com/projectpotos/ansible-specs-potos) at first boot only.