### PR TITLE
fix(uefi): make uefi installations available

### DIFF
--- a/potos-iso/autoinstall/desktop-uefi/user-data
+++ b/potos-iso/autoinstall/desktop-uefi/user-data
@@ -1,5 +1,4 @@
----
-# cloud-config
+#cloud-config
 autoinstall:
   version: 1
   apt:
@@ -11,11 +10,7 @@ autoinstall:
     hostname: potosmachine
     # echo -n admin | mkpasswd --method=SHA-512 --stdin
     password: $6$CqhJvUmnavRWOv50$nTru/In4/PHD7oP0XQih61IXEfzHOC/8BJ3quYbaxE8uKUSO6XbgbIdUOYQgI5bShTa2doRqwyQAPxh1LDJLJ/
-    username: adminpotos
-  keyboard:
-    layout: us
-    variant: ''
-  locale: en_US
+    username: admin
   ssh:
     allow-pw: true
     authorized-keys: []
@@ -110,7 +105,7 @@ autoinstall:
     - ubuntu-desktop
     - plymouth-theme-ubuntu-logo
     - ldap-utils
-    - ansible-core
+    - ansible
     - yad
     - jq
   late-commands:
@@ -122,12 +117,12 @@ autoinstall:
             ;;
         esac
       done
-    #- sed -ie 's|GRUB_CMDLINE_LINUX_DEFAULT=.*|GRUB_CMDLINE_LINUX_DEFAULT="nomodeset quiet splash gnome.initial-setup=1 systemd.debug_shell"|' /target/etc/default/grub
-    #- cp /cdrom/contrib/sudoers.d/01_gnome-initial-setup /target/etc/sudoers.d/01_gnome-initial-setup
-    #- cp -r /cdrom/contrib/scripts /target/setup
-    #- curtin in-target --target=/target -- ln -sf /setup/firstboot-gui.sh /usr/libexec/gnome-initial-setup
-    #- curtin in-target --target=/target -- update-grub
-    - mkdir /target/potos
-    - touch /target/potos/example.empty
+    - sed -ie 's|GRUB_CMDLINE_LINUX_DEFAULT=.*|GRUB_CMDLINE_LINUX_DEFAULT="quiet splash gnome.initial-setup=1 systemd.debug_shell"|' /target/etc/default/grub
+    - rm -f /target/etc/netplan/*
+    - cp /cdrom/contrib/netplan/01-network-manager-all.yaml /target/etc/netplan/01-network-manager-all.yaml
+    - cp /cdrom/contrib/sudoers.d/01_gnome-initial-setup /target/etc/sudoers.d/01_gnome-initial-setup
+    - cp -r /cdrom/contrib/scripts /target/setup
+    - curtin in-target --target=/target -- ln -sf /setup/firstboot-gui.sh /usr/libexec/gnome-initial-setup
+    - curtin in-target --target=/target -- update-grub
 
 # vim: filetype=yaml

--- a/potos-iso/create-iso
+++ b/potos-iso/create-iso
@@ -69,7 +69,7 @@ build_iso() {
 MBR_FILE=boot_hybrid.img
 
 dd if=${ORIG_ISO} bs=1 count=432 of=${MBR_FILE}
-dd if=${ORIG_ISO} bs=512 skip=2855516 count=8496 of=efi.img
+dd if=${ORIG_ISO} bs=512 skip=2871452 count=8496 of=efi.img
 
 xorriso -as mkisofs -r -V '${POTOS_CLIENT_NAME} 22.04' \
 -o ${POTOS_CLIENT_SHORTNAME}-installer-${ENVIRONMENT}.iso \


### PR DESCRIPTION
## Description

- [x] Fix UEFI Boot & Installation
  - [x] Boot solution: extracting the efi.img was wrongly from the older `ubuntu-22.04-live-server-amd64.iso`, but we're already running unattended installation with `ubuntu-22.04.1-live-server-amd64.iso`. Skip size <strike>2855516</strike> 2871452. You can check the starting point with fdisk -l *.iso
  - [x] Unattended installation: furthermore, the uefi autoinstall is now fixed, it's aligned to the bios pendant.

Fixes #10  (issue)
