### PR TITLE
refactor(docker-compose): raise minimal required docker version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 ---
-version: "3.2"
+version: "3.8"
 services:
   potos-iso-creation:
     build:


### PR DESCRIPTION
## Description

I would like to raise the minimal docker version, as there is (was) a difference in env variable handling between docker and docker-compose. Docker from Ubuntu 20.04 repos creates invalid images.

v3.8 is not any more affected and should be the version, and is shipped with docker/docker-compose from Ubuntu 22.04 Repos.