### PR TITLE
fix: keyboard layout set mru

### DIFF
--- a/container/change-keyboard-layout.j2
+++ b/container/change-keyboard-layout.j2
@@ -17,6 +17,7 @@ KEYBOARD_LAYOUT=$(echo ${KEYBOARD_LAYOUT} | tr -d '|')
 
 # Write this setting into current gnome session, as non-root user
 gsettings set org.gnome.desktop.input-sources sources "[('xkb', '${KEYBOARD_LAYOUT}')]"
+gsettings set org.gnome.desktop.input-sources mru-sources "[('xkb', '${KEYBOARD_LAYOUT}')]"
 
 # Write this settings permamently, keep them after reboot, as root user
 sudo sed -i 's/XKBLAYOUT=\".*"/XKBLAYOUT=\"'${KEYBOARD_LAYOUT}'\"/g' /etc/default/keyboard


### PR DESCRIPTION
## Description

Cross fixing from other Linux client, in some version of Gnome it is not enough to set `org.gnome.desktop.input-sources sources` to the selected keyboard layout. On first login of a user it falls back to the US-Layout, if most recently used (mru) is not explicitly set. Thus this PR sets `org.gnome.desktop.input-sources mru-sources` to fix this issue

## Dependencies

n/a
