### PR TITLE
feat: add specs ssh deploy key and ansible-vault key support

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -9,6 +9,8 @@ specs:
   url: "https://github.com/projectpotos/"
   repo: "ansible-specs-potos"
   branch: "main"
+  ssh_key: ""  # eg. ssh_key: "potos_specs_key" for `potos_specs_key` in this config directory
+  ansible-vault-key-file: ""  # same as ssh_key, but for the file with the ansible-vault key
 initial_hostname: "potoshostname01"
 initial_user:
   username: "admin"

--- a/container/autoinstall-user-data.j2
+++ b/container/autoinstall-user-data.j2
@@ -149,6 +149,13 @@ autoinstall:
     - rm -f /target/etc/netplan/*
     - cp /cdrom/setup/default-netplan.yml /target/etc/netplan/01-network-manager-all.yaml
     - cp /cdrom/setup/gnome-sudo /target/etc/sudoers.d/01_gnome-initial-setup
+    - mkdir -p /target/etc/potos/ && chown 0:0 /target/etc/potos/ && chmod 0700 /target/etc/potos/
+{% if POTOS_GIT_SPECS_SSH_KEY != "" %}
+    - cp /cdrom/setup/specs_key /target/etc/potos/specs_key && chown 0:0 /target/etc/potos/specs_key && chmod 0400 /target/etc/potos/specs_key 
+{% endif %}
+{% if POTOS_GIT_SPECS_ANSIBLE_VAULT != "" %}
+    - cp /cdrom/setup/ansible_vault_key /target/etc/potos/ansible_vault_key && chown 0:0 /target/etc/potos/ansible_vault_key && chmod 0500 /target/etc/potos/ansible_vault_key 
+{% endif %}
     - cp -r /cdrom/setup /target/setup
     - curtin in-target --target=/target -- ln -sf /setup/firstboot-gui.sh /usr/libexec/gnome-initial-setup
     - curtin in-target --target=/target -- update-grub

--- a/container/build-iso
+++ b/container/build-iso
@@ -15,6 +15,8 @@ export POTOS_DISK_ENCRYPTION_INITIAL_PASSWORD=$(loadYmlVar '.disk_encryption.ini
 export POTOS_GIT_SPECS_URL=$(loadYmlVar '.specs.url' "https://github.com/projectpotos/")
 export POTOS_GIT_SPECS_REPO=$(loadYmlVar '.specs.repo' "ansible-specs-potos")
 export POTOS_GIT_SPECS_BRANCH=$(loadYmlVar '.specs.branch' "main")
+export POTOS_GIT_SPECS_SSH_KEY=$(loadYmlVar '.specs.ssh_key' "")
+export POTOS_GIT_SPECS_ANSIBLE_VAULT=$(loadYmlVar '.specs.ansible-vault-key-file' "")
 export POTOS_INITIAL_HOSTNAME=$(loadYmlVar '.initial_hostname' "potoshostname01")
 export POTOS_INITIAL_USERNAME=$(loadYmlVar '.initial_user.username' "admin")
 export POTOS_INITIAL_PASSWORD_HASH=$(loadYmlVar '.initial_user.password' '$6$L36BiUuVCSipvlO8$oGI0C.LXZegkbftFkVDXXaasTM6zs9LM71BkqZToKw5aOZ7Yr70pkzH3P9Xz5R.n0ULJ0Zf8v5ZQ/eH8flDR7/')
@@ -113,6 +115,15 @@ if [ -f /config/logo.png ]; then
   cp logo.png "${TMP_DIR}/setup/logo.png"
 else
   cp /config/logo.png "${TMP_DIR}/setup/logo.png"
+fi
+
+# copy ssh deploy key for specs repo into image
+if [ -n "${POTOS_GIT_SPECS_SSH_KEY}" ] && [ -f "/config/${POTOS_GIT_SPECS_SSH_KEY}" ]; then
+  cp "/config/${POTOS_GIT_SPECS_SSH_KEY}" "${TMP_DIR}/setup/specs_key"
+fi
+# copy ansible-vault key for specs repo into image
+if [ -n "${POTOS_GIT_SPECS_ANSIBLE_VAULT}" ] && [ -f /config/${POTOS_GIT_SPECS_ANSIBLE_VAULT} ]; then
+  cp "/config/${POTOS_GIT_SPECS_ANSIBLE_VAULT}" "${TMP_DIR}/setup/ansible_vault_key"
 fi
 
 # template diverse files for firstboot

--- a/container/finish.sh.j2
+++ b/container/finish.sh.j2
@@ -11,10 +11,6 @@ ANSIBLE_WORKDIR='/tmp/potos_ansible'
 ANSIBLE_GIT_URL='https://github.com/projectpotos/ansible-plays-potos.git'
 ANSIBLE_GIT_BRANCH='main'
 
-if [[ -d "/etc/potos" ]]; then
-  rm -rf "/etc/potos"
-fi
-
 mkdir -p "/etc/potos"
 mkdir -p "/var/log/{{ POTOS_CLIENT_SHORTNAME }}"
 
@@ -25,7 +21,11 @@ client_short_name: "{{ POTOS_CLIENT_SHORTNAME }}"
 git_url: "{{ POTOS_GIT_SPECS_URL }}"
 git_repo: "{{ POTOS_GIT_SPECS_REPO }}"
 git_branch: "{{ POTOS_GIT_SPECS_BRANCH }}"
+git_ssh_key: "{{ POTOS_GIT_SPECS_SSH_KEY != "" }}"
+git_ansible_vault: "{{ POTOS_GIT_SPECS_ANSIBLE_VAULT != "" }}"
 EOF
+
+chown 0:0 /etc/potos/specs_repo.yml && chmod 0400 /etc/potos/specs_repo.yml
 
 if [[ -d "${ANSIBLE_WORKDIR}" ]]; then
   rm -rf "${ANSIBLE_WORKDIR}"
@@ -33,7 +33,11 @@ fi
 
 mkdir -p "${ANSIBLE_WORKDIR}"
 
+{% if POTOS_GIT_SPECS_SSH_KEY != "" %}
+GIT_SSH_COMMAND='ssh -i /etc/potos/specs_key -o StrictHostKeyChecking=accept-new' git clone --single-branch --branch "${ANSIBLE_GIT_BRANCH}" "${ANSIBLE_GIT_URL}" "${ANSIBLE_WORKDIR}"
+{% else %}
 git clone --single-branch --branch "${ANSIBLE_GIT_BRANCH}" "${ANSIBLE_GIT_URL}" "${ANSIBLE_WORKDIR}"
+{% endif %}
 
 if [[ $? -ne 0 ]]; then
   echo "# ERROR: Failed to clone the git repository"
@@ -51,8 +55,8 @@ source bin/activate
 pip3 install ansible-core==2.12.3
 
 {# Verbose ansible if develop #}
-ansible-playbook prepare.yml {% if POTOS_ENV is defined and POTOS_ENV == 'develop' %}-vvv {% endif %}| sed -u 's/^/# /'
-ansible-playbook playbook.yml {% if POTOS_ENV is defined and POTOS_ENV == 'develop' %}-vvv {% endif %}-e "{{ POTOS_CLIENT_SHORTNAME }}_runtype"="{{ POTOS_RUNTYPE }}" | sed -u 's/^/# /'
+ansible-playbook prepare.yml {% if POTOS_GIT_SPECS_ANSIBLE_VAULT != "" %}--vault-password-file=/etc/potos/ansible_vault_key {% endif %}{% if POTOS_ENV is defined and POTOS_ENV == 'develop' %}-vvv {% endif %}| sed -u 's/^/# /'
+ansible-playbook playbook.yml {% if POTOS_GIT_SPECS_ANSIBLE_VAULT != "" %}--vault-password-file=/etc/potos/ansible_vault_key {% endif %}{% if POTOS_ENV is defined and POTOS_ENV == 'develop' %}-vvv {% endif %}-e "{{ POTOS_CLIENT_SHORTNAME }}_runtype"="{{ POTOS_RUNTYPE }}" | sed -u 's/^/# /'
 
 deactivate
 

--- a/container/firstboot-gui.sh.j2
+++ b/container/firstboot-gui.sh.j2
@@ -24,7 +24,8 @@ disk_encryption.init_password: {{ POTOS_DISK_ENCRYPTION_INITIAL_PASSWORD }}
 specs.url: {{ POTOS_GIT_SPECS_URL }}
 specs.repo: {{ POTOS_GIT_SPECS_REPO }}
 specs.branch: {{ POTOS_GIT_SPECS_BRANCH }}
-
+specs.ssh_key: {% if POTOS_GIT_SPECS_SSH_KEY == "" %}not {% endif %}specified
+specs.ansible-vault-key-file: {% if POTOS_GIT_SPECS_ANSIBLE_VAULT == "" %}not {% endif %}specified
 initial_hostname: {{ POTOS_INITIAL_HOSTNAME }}
 
 initial_user.username: {{ POTOS_INITIAL_USERNAME }}


### PR DESCRIPTION
## Description

Allowing to specify an ssh deploy key for the specs repo as well as ansible-vault key

## Dependencies

[#9](https://github.com/projectpotos/ansible-role-potos_basics/pull/9) and [#11](https://github.com/projectpotos/ansible-plays-potos/pull/11) have a soft dependency on this.