### PR TITLE
feat: actually make use of swap partition

### DIFF
--- a/container/autoinstall-user-data.j2
+++ b/container/autoinstall-user-data.j2
@@ -127,6 +127,10 @@ autoinstall:
         device: format_boot
         path: /boot
         type: mount
+      - id: mount_swap
+        device: format_swap
+        path: none
+        type: mount
       - id: mount_root
         device: format_root
         path: /


### PR DESCRIPTION
## Description

While attempting to test the hibernate feature on my potos based client,
I discovered that while the configured swap partition was created, there
was no entry in `/target/etc/fstab` for it.

Instead `curtin` decided to create a 4GiB swap file instead:

```
start: cmd-install/stage-curthooks/builtin/cmd-curthooks/setting-up-swap: setting up swap
Running command ['findmnt', '--noheading', '--target', '/target/', '-o', 'FSTYPE'] with allowed return codes [0] (capture=True)
Running command ['sh', '-c', 'rm -f "$1" && umask 0066 && truncate -s 0 "$1" && { chattr +C "$1" || true; } && fallocate -l "${2}M" "$1" && mkswap "$1" || { r=$?; rm -f "$1"; exit $r; }', 'setup_swap', '/target//swap.img', '4096'] with allowed return codes [0] (capture=False)
chattr: Operation not supported while setting flags on /target//swap.img
Setting up swapspace version 1, size = 4 GiB (4294963200 bytes)
no label, UUID=6ed52ac8-827a-4eb9-94c2-050df54c1db5
creating swapfile '/swap.img' of 4096MB took 0.029 seconds
finish: cmd-install/stage-curthooks/builtin/cmd-curthooks/setting-up-swap: SUCCESS: setting up swap
```

This fix makes `curtin` to do the right thing, my `fstab` had this line after an install:

```
admin@mlc0:~$ grep swap /etc/fstab
/dev/disk/by-id/dm-uuid-LVM-l9zKG2KJEspwAVMhGgPz3NJkWOjg8eUYreDc6dHxBzMN5rBJSGjLbCmZuC1xUbqm none swap sw 0 0
```

## Dependencies

none (yet).