### PR TITLE
Draft: fix: runtype_var_name workaround

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -1,25 +1,29 @@
 ---
 client_name:
-  long: "Potos Linux Client"
-  short: "potos"
+  long: "m Linux Client"
+  short: "mlc"
 disk_encryption:
-  enable: false
+  enable: true
   init_password: "install"
 specs:
-  url: "https://github.com/projectpotos/"
-  repo: "ansible-specs-potos"
+  url: "https://github.com/nis65/"
+  repo: "ansible-specs-potos-mlc"
   branch: "main"
   ssh_key: ""  # eg. ssh_key: "potos_specs_key" for `potos_specs_key` in this config directory
   ansible-vault-key-file: ""  # same as ssh_key, but for the file with the ansible-vault key
-initial_hostname: "potoshostname01"
+initial_hostname: "mlc0"
 initial_user:
   username: "admin"
   password: "$6$L36BiUuVCSipvlO8$oGI0C.LXZegkbftFkVDXXaasTM6zs9LM71BkqZToKw5aOZ7Yr70pkzH3P9Xz5R.n0ULJ0Zf8v5ZQ/eH8flDR7/"
-environment: "production"
+environment: "develop"
 first_boot_ansible:
   runtype: "setup"
-full_unattended_install: false
+full_unattended_install: true
+wifi:
+  interface: "wlp1s0"
+  ssid: "REDACTED"
+  pw: "REDACTED"
 os: "jammy"
 output:
   version: "%Y%m%d"
-  iso_filename: "potos-installer.iso"
+  iso_filename: "potos-mlc-installer.iso"

--- a/container/autoinstall-user-data.j2
+++ b/container/autoinstall-user-data.j2
@@ -103,13 +103,13 @@ autoinstall:
       - id: lvm_volume_swap
         name: swap
         volgroup: lvm_volgroup_0
-        size: 1G
+        size: 16G
         preserve: false
         type: lvm_partition
       - id: lvm_volume_root
         name: root
         volgroup: lvm_volgroup_0
-        size: -1
+        size: 50G
         preserve: false
         type: lvm_partition
 {% if autoinstall_type == 'uefi' %}

--- a/container/autoinstall-user-data.j2
+++ b/container/autoinstall-user-data.j2
@@ -127,6 +127,10 @@ autoinstall:
         device: format_boot
         path: /boot
         type: mount
+      - id: mount_swap
+        device: format_swap
+        path: none
+        type: mount
       - id: mount_root
         device: format_root
         path: /

--- a/container/autoinstall-user-data.j2
+++ b/container/autoinstall-user-data.j2
@@ -10,6 +10,23 @@ autoinstall:
     hostname: {{ config['initial_hostname'] | default('potoshostname01') }}
     password: {{ config['initial_user']['password'] | default('$6$L36BiUuVCSipvlO8$oGI0C.LXZegkbftFkVDXXaasTM6zs9LM71BkqZToKw5aOZ7Yr70pkzH3P9Xz5R.n0ULJ0Zf8v5ZQ/eH8flDR7/') }}
     username: {{ config['initial_user']['username'] | default('admin') }}
+{% if config['wifi'] is defined %}
+  early-commands:
+    - apt-get -y install wpasupplicant
+  drivers:
+    install: true
+  network:
+    # https://ubuntu.com/server/docs/install/autoinstall-reference#network
+    # https://netplan.readthedocs.io/en/stable/netplan-yaml/#properties-for-device-type-wifis
+    version: 2
+    wifis:
+      {{ config['wifi']['interface'] }}:
+        access-points:
+          "{{ config['wifi']['ssid'] }}":
+            password: "{{ config['wifi']['pw'] }}"
+        dhcp4: true
+        dhcp6: true
+{% endif %}
   ssh:
     allow-pw: true
     authorized-keys: []

--- a/container/build-iso
+++ b/container/build-iso
@@ -20,6 +20,9 @@ export POTOS_GIT_SPECS_ANSIBLE_VAULT=$(loadYmlVar '.specs.ansible-vault-key-file
 export POTOS_INITIAL_HOSTNAME=$(loadYmlVar '.initial_hostname' "potoshostname01")
 export POTOS_INITIAL_USERNAME=$(loadYmlVar '.initial_user.username' "admin")
 export POTOS_INITIAL_PASSWORD_HASH=$(loadYmlVar '.initial_user.password' '$6$L36BiUuVCSipvlO8$oGI0C.LXZegkbftFkVDXXaasTM6zs9LM71BkqZToKw5aOZ7Yr70pkzH3P9Xz5R.n0ULJ0Zf8v5ZQ/eH8flDR7/')
+export POTOS_WIFI_INTERFACE=$(loadYmlVar 'wifi.interface' "nowifi")
+export POTOS_WIFI_SSID=$(loadYmlVar 'wifi.ssid' "nossid")
+export POTOS_WIFI_PW=$(loadYmlVar 'wifi.pw' "noPW")
 export POTOS_ENV=$(loadYmlVar '.environment' "production")
 export POTOS_RUNTYPE=$(loadYmlVar '.first_boot_ansible.runtype' "setup")
 export POTOS_FULL_UNATTENDED=$(loadYmlVar '.full_unattended_install' "false")
@@ -42,7 +45,7 @@ REQUIREMENTS="7z gfxboot xorriso wget curl sha256sum j2"
 
 # Print environment info
 if [[ ${POTOS_ENV} == "develop" ]]; then
-  echo "*** POTOS_ENV is ${POTOS_ENV}, going to print some more informations for you:"
+  echo "*** POTOS_ENV is ${POTOS_ENV}, going to print some more information for you:"
   printenv | grep -i potos
   echo "POTOS_PRE_INSTALL_PACKAGES="
   for t in ${POTOS_PRE_INSTALL_PACKAGES[@]}; do echo "- $t"; done

--- a/container/build-iso.py
+++ b/container/build-iso.py
@@ -34,6 +34,10 @@ with open("/config/config.yml", "r") as f:
         config['initial_user'] = {}
         config['initial_user']['username'] = ymlconfig.get("initial_user",{}).get('username',"admin")
         config['initial_user']['password'] = ymlconfig.get("initial_user",{}).get('password',"$6$L36BiUuVCSipvlO8$oGI0C.LXZegkbftFkVDXXaasTM6zs9LM71BkqZToKw5aOZ7Yr70pkzH3P9Xz5R.n0ULJ0Zf8v5ZQ/eH8flDR7/")
+        config['wifi'] = {}
+        config['wifi']['interface'] = ymlconfig.get("wifi",{}).get('interface',"wlan0")
+        config['wifi']['ssid'] = ymlconfig.get("wifi",{}).get('ssid',"yourwifissid")
+        config['wifi']['pw'] = ymlconfig.get("wifi",{}).get('pw',"yourwifipassword")
         config['environment'] = ymlconfig.get("environment","production")
         config['first_boot_ansible'] = {}
         config['first_boot_ansible']['runtype'] = ymlconfig.get("first_boot_ansible",{}).get('runtype',"setup")
@@ -101,7 +105,7 @@ else:
 # Print config info
 if config['environment'] == "develop":
     print(
-        "*** config.environment is %s, going to print some more informations for you:"%(
+        "*** config.environment is %s, going to print some more information for you:"%(
             config['environment'],
         )
     )

--- a/container/finish.sh.j2
+++ b/container/finish.sh.j2
@@ -56,7 +56,7 @@ pip3 install ansible-core==2.12.3
 
 {# Verbose ansible if develop #}
 ansible-playbook prepare.yml {% if config['specs']['ansible_vault_key_file'] != "" %}--vault-password-file=/etc/potos/ansible_vault_key {% endif %}{% if POTOS_ENV is defined and POTOS_ENV == 'develop' %}-vvv {% endif %}| sed -u 's/^/# /'
-ansible-playbook playbook.yml {% if config['specs']['ansible_vault_key_file'] != "" %}--vault-password-file=/etc/potos/ansible_vault_key {% endif %}{% if POTOS_ENV is defined and POTOS_ENV == 'develop' %}-vvv {% endif %}-e "{{ config['client_name']['short'] }}_runtype"="{{ config['first_boot_ansible']['runtype'] }}" | sed -u 's/^/# /'
+ansible-playbook playbook.yml {% if config['specs']['ansible_vault_key_file'] != "" %}--vault-password-file=/etc/potos/ansible_vault_key {% endif %}{% if POTOS_ENV is defined and POTOS_ENV == 'develop' %}-vvv {% endif %}-e "potos_runtype"="{{ config['first_boot_ansible']['runtype'] }}" | sed -u 's/^/# /'
 
 deactivate
 


### PR DESCRIPTION
## Description

this (together with the other MR) was needed on my setup to get first boot to work at all.

## Dependencies

#43 and #44 should be merged first (then you won't see that big a delta any more, sorry about that).
I need to clean out some files that don't belong here (again) 

See MR in other [potos repo](https://github.com/projectpotos/ansible-role-potos_basics/pull/26) and MR in [my own specs repo](https://github.com/nis65/ansible-specs-potos-mlc/pull/12)