### PR TITLE
fix!: runtype var name must be static

### DIFF
--- a/container/finish.sh.j2
+++ b/container/finish.sh.j2
@@ -56,7 +56,7 @@ pip3 install ansible-core==2.12.3
 
 {# Verbose ansible if develop #}
 ansible-playbook prepare.yml {% if config['specs']['ansible_vault_key_file'] != "" %}--vault-password-file=/etc/potos/ansible_vault_key {% endif %}{% if POTOS_ENV is defined and POTOS_ENV == 'develop' %}-vvv {% endif %}| sed -u 's/^/# /'
-ansible-playbook playbook.yml {% if config['specs']['ansible_vault_key_file'] != "" %}--vault-password-file=/etc/potos/ansible_vault_key {% endif %}{% if POTOS_ENV is defined and POTOS_ENV == 'develop' %}-vvv {% endif %}-e "{{ config['client_name']['short'] }}_runtype"="{{ config['first_boot_ansible']['runtype'] }}" | sed -u 's/^/# /'
+ansible-playbook playbook.yml {% if config['specs']['ansible_vault_key_file'] != "" %}--vault-password-file=/etc/potos/ansible_vault_key {% endif %}{% if POTOS_ENV is defined and POTOS_ENV == 'develop' %}-vvv {% endif %}-e "potos_runtype"="{{ config['first_boot_ansible']['runtype'] }}" | sed -u 's/^/# /'
 
 deactivate
 


### PR DESCRIPTION
## Description

This (together with the other MR) was needed on my setup to get first boot to work at all.


## Dependencies

* This should should be merged at the same time as this [MR in the basics role](https://github.com/projectpotos/ansible-role-potos_basics/pull/27)
* This replaces the dirty and closed MR #45 (for the same issue)

This is a breaking change as users that made use of `potos_basics_ansible_runtype_var_name` will lose that
feature (well, I doubt that it was usable - i.e. if you could set it to anything else than `potos_runtype` at all before :smile:)

