### PR TITLE
fix: make wired configs work again

### DIFF
--- a/container/autoinstall-user-data.j2
+++ b/container/autoinstall-user-data.j2
@@ -10,7 +10,7 @@ autoinstall:
     hostname: {{ config['initial_hostname'] | default('potoshostname01') }}
     password: {{ config['initial_user']['password'] | default('$6$L36BiUuVCSipvlO8$oGI0C.LXZegkbftFkVDXXaasTM6zs9LM71BkqZToKw5aOZ7Yr70pkzH3P9Xz5R.n0ULJ0Zf8v5ZQ/eH8flDR7/') }}
     username: {{ config['initial_user']['username'] | default('admin') }}
-{% if config['wifi']['ssid'] is defined %}
+{% if config['wifi']['interface'] is defined and config['wifi']['interface'] != None %}
   early-commands:
     - apt-get -y install wpasupplicant
   drivers:

--- a/container/build-iso.py
+++ b/container/build-iso.py
@@ -35,9 +35,9 @@ with open("/config/config.yml", "r") as f:
         config['initial_user']['username'] = ymlconfig.get("initial_user",{}).get('username',"admin")
         config['initial_user']['password'] = ymlconfig.get("initial_user",{}).get('password',"$6$L36BiUuVCSipvlO8$oGI0C.LXZegkbftFkVDXXaasTM6zs9LM71BkqZToKw5aOZ7Yr70pkzH3P9Xz5R.n0ULJ0Zf8v5ZQ/eH8flDR7/")
         config['wifi'] = {}
-        config['wifi']['interface'] = ymlconfig.get("wifi",{}).get('interface',"wlan0")
-        config['wifi']['ssid'] = ymlconfig.get("wifi",{}).get('ssid',"yourwifissid")
-        config['wifi']['pw'] = ymlconfig.get("wifi",{}).get('pw',"yourwifipassword")
+        config['wifi']['interface'] = ymlconfig.get("wifi",{}).get('interface')
+        config['wifi']['ssid'] = ymlconfig.get("wifi",{}).get('ssid')
+        config['wifi']['pw'] = ymlconfig.get("wifi",{}).get('pw')
         config['environment'] = ymlconfig.get("environment","production")
         config['first_boot_ansible'] = {}
         config['first_boot_ansible']['runtype'] = ymlconfig.get("first_boot_ansible",{}).get('runtype',"setup")


### PR DESCRIPTION
## Description

The new feature to enable wireless installs using the `wifi` config setting was flawed when no wifi was configured/desired:

* `build-iso.py` set a an explicit default, so 
* `autoinstall-user-data.j2` always configured a wifi connection (using the silly preset values). That of course failed. Which caused the installation to abort.

Now, 
* `ymlconfig.get` (in `build-iso.py`) sets the unset values implicitly to `None` 
* which is then explicitly checked for in the `autoinstall-user-data.j2` template.

## Dependencies

none