### PR TITLE
fix: make ansible-galaxy work again with community.general

### DIFF
--- a/container/finish.sh.j2
+++ b/container/finish.sh.j2
@@ -52,7 +52,7 @@ cd "${ANSIBLE_WORKDIR}"
 
 virtualenv .
 source bin/activate
-pip3 install ansible-core==2.12.3
+pip3 install ansible-core==2.12.10
 
 {# Verbose ansible if develop #}
 ansible-playbook prepare.yml {% if config['specs']['ansible_vault_key_file'] != "" %}--vault-password-file=/etc/potos/ansible_vault_key {% endif %}{% if POTOS_ENV is defined and POTOS_ENV == 'develop' %}-vvv {% endif %}| sed -u 's/^/# /'


### PR DESCRIPTION
## Description

I recently tried to install a client from an iso i created a few weeks ago and it failed with the error
messages as described e.g. [in this bug](https://github.com/ansible/awx/issues/14495)

## Dependencies

See [this MR](https://github.com/projectpotos/ansible-role-potos_basics/pull/38) in the ansible-role-potos_basics repo.