### PR TITLE
fix: don't systemd-networkd-wait-online

### DIFF
--- a/container/autoinstall-user-data.j2
+++ b/container/autoinstall-user-data.j2
@@ -168,6 +168,7 @@ autoinstall:
     - sed -ie 's|GRUB_CMDLINE_LINUX_DEFAULT=.*|GRUB_CMDLINE_LINUX_DEFAULT="quiet splash gnome.initial-setup=1 systemd.debug_shell"|' /target/etc/default/grub
     - rm -f /target/etc/netplan/*
     - cp /cdrom/setup/default-netplan.yml /target/etc/netplan/01-network-manager-all.yaml
+    - curtin in-target --target=/target -- rm /etc/systemd/system/network-online.target.wants/systemd-networkd-wait-online.service
     - cp /cdrom/setup/gnome-sudo /target/etc/sudoers.d/01_gnome-initial-setup
     - mkdir -p /target/etc/potos/ && chown 0:0 /target/etc/potos/ && chmod 0700 /target/etc/potos/
 {% if config['specs']['ssh_key'] != "" %}


### PR DESCRIPTION
## Description

Very often during first boot I lost network connectivity. This could
be tracked down by other installations to a conflict of systemd-networkd
(the default on Ubuntu Servers) and NetworkManager (the default
on Ubuntu clients). 

The fix is related to several changes in Mützi Linux Client, e.g.

* [hibernate role](https://github.com/nis65/ansible-role-potos_hibernate/blob/715c58a33a4051582d1ef1129d4ab9733963865d/tasks/main.yml#L27-L31) (well, that should be somewhere else I guess).
* [apt config](https://github.com/nis65/ansible-specs-potos-mlc/blob/51b57f08282d14909a981fd36b150da00216d59c/vars/potos_apt.yml#L66-L67), removing the `cloud-init` Package (that is used only on the ISO, not in the installed system).

I did not track down if this new change would make the two changes above obsolete, but I am fine on my side with the current situation

## Dependencies

none.

## See also
* e.g.: https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/2036358