### PR TITLE
fix: prevent first boot name resolution failures

### DIFF
--- a/container/autoinstall-user-data.j2
+++ b/container/autoinstall-user-data.j2
@@ -169,6 +169,7 @@ autoinstall:
     - rm -f /target/etc/netplan/*
     - cp /cdrom/setup/default-netplan.yml /target/etc/netplan/01-network-manager-all.yaml
     - curtin in-target --target=/target -- rm /etc/systemd/system/network-online.target.wants/systemd-networkd-wait-online.service
+    - curtin in-target --target=/target -- ln -s /dev/null /etc/systemd/system/systemd-networkd.service
     - cp /cdrom/setup/gnome-sudo /target/etc/sudoers.d/01_gnome-initial-setup
     - mkdir -p /target/etc/potos/ && chown 0:0 /target/etc/potos/ && chmod 0700 /target/etc/potos/
 {% if config['specs']['ssh_key'] != "" %}


### PR DESCRIPTION
## Description

Without masking systemd-networkd before first boot, there were often (the slower the hardware, the more likely) failures in name resolution during first boot. Everything went well until at some point in time the dns resolution stopped working and the install of each single apt package took 3 minutes. Although the installation finishes more or less successfully and the missing packages are installed by the first ansible pull after 2nd boot, it can prolong first boot time by 60 minutes or more.

There might be more elegant solutions, but it looks so wrong to have both the  (ubuntu server) systemd-networkd and (ubuntu client) NetworkManager network managements active at the same time.
