### PR TITLE
feat: make adjustments for 24.04 support

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -18,7 +18,7 @@ env:
 # Kudos to https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows
 jobs:
   build-publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       packages: write
       contents: read

--- a/config/config.yml
+++ b/config/config.yml
@@ -23,7 +23,7 @@ full_unattended_install: false
 #   interface: "wlp1s0"
 #   ssid: "REDACTED"
 #   pw: "REDACTED"
-os: "jammy"
+os: "noble"
 output:
   version: "%Y%m%d"
   iso_filename: "potos-installer.iso"

--- a/container/99needrestart
+++ b/container/99needrestart
@@ -1,0 +1,9 @@
+# needrestart - Restart daemons after library updates.
+#
+# Call needrestart after package upgrades/installations and check
+# for pending service restarts. Should only be triggered if there
+# was no error during installation.
+#
+
+DPkg::Post-Invoke {"test -x /usr/lib/needrestart/apt-pinvoke && /usr/lib/needrestart/apt-pinvoke || true"; };
+

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -3,9 +3,7 @@ FROM ubuntu:24.04
 WORKDIR /potos-iso
 
 # Install ISO creation depencies
-RUN apt update && apt install -y gfxboot p7zip-full xorriso wget curl libhtml-parser-perl cpio whois python3 python3-pip fdisk squashfs-tools python3-requests
-COPY requirements.txt .
-RUN pip3 install -r requirements.txt --break-system-packages
+RUN apt update && apt install -y gfxboot p7zip-full xorriso wget curl libhtml-parser-perl cpio whois python3 python3-pip fdisk squashfs-tools python3-requests python3-jinja2 python3-yaml
 
 # Create config directory
 RUN mkdir /config

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,11 +1,11 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 WORKDIR /potos-iso
 
 # Install ISO creation depencies
 RUN apt update && apt install -y gfxboot p7zip-full xorriso wget curl libhtml-parser-perl cpio whois python3 python3-pip fdisk squashfs-tools python3-requests
 COPY requirements.txt .
-RUN pip3 install -r requirements.txt
+RUN pip3 install -r requirements.txt --break-system-packages
 
 # Create config directory
 RUN mkdir /config

--- a/container/autoinstall-user-data.j2
+++ b/container/autoinstall-user-data.j2
@@ -171,6 +171,9 @@ autoinstall:
     - curtin in-target --target=/target -- rm /etc/systemd/system/network-online.target.wants/systemd-networkd-wait-online.service
     - curtin in-target --target=/target -- ln -s /dev/null /etc/systemd/system/systemd-networkd.service
     - cp /cdrom/setup/gnome-sudo /target/etc/sudoers.d/01_gnome-initial-setup
+{% if config['os'] == "noble" %}
+    - cp /cdrom/setup/99needrestart /target/etc/apt/apt.conf.d/
+{% endif %}
     - mkdir -p /target/etc/potos/ && chown 0:0 /target/etc/potos/ && chmod 0700 /target/etc/potos/
 {% if config['specs']['ssh_key'] != "" %}
     - cp /cdrom/setup/specs_key /target/etc/potos/specs_key && chown 0:0 /target/etc/potos/specs_key && chmod 0400 /target/etc/potos/specs_key 

--- a/container/build-iso.py
+++ b/container/build-iso.py
@@ -68,19 +68,19 @@ def get_latest_minor_release(version):
     match = re.search(rf"ubuntu-{version}\.(\d+)-live-server-amd64\.iso", response.text)
 
     if match:
-        return match.group(1)
+        return str(match.group(1))
 
     raise ValueError(f"Could not find a valid minor release for Ubuntu {version}.")
 
 # switch iso by selected os
 if config['os'] == "noble":
-    version = 24.04
+    version = "24.04"
     minor_version = get_latest_minor_release(version)
     config['input'] = {}
-    config['input']['iso_filename'] = f"ubuntu-{version}.{minor_version}-live-server-amd64.iso"
-    config['input']['iso_url'] = "https://releases.ubuntu.com/24.04/" + config['input']['iso_filename']
+    config['input']['iso_filename'] = "ubuntu-" + version + "." + minor_version + "-live-server-amd64.iso"
+    config['input']['iso_url'] = "https://releases.ubuntu.com/"+ version + "/" +config['input']['iso_filename']
     config['input']['sha256_filename'] = "SHA256SUMS"
-    config['input']['sha256_url'] = "https://releases.ubuntu.com/24.04/SHA256SUMS"
+    config['input']['sha256_url'] = "https://releases.ubuntu.com/" + version + "/SHA256SUMS"
     config['packages'] = {}
     config['packages']['preinstall'] = [
         "python3-virtualenv",
@@ -95,17 +95,17 @@ if config['os'] == "noble":
     if response.status_code == 404:
         #extract figures in between first both dashes.
         version = config['input']['iso_filename'].split("-")[1]
-        config['input']['iso_url'] = "https://releases.ubuntu.com/24.04/" + config['input']['iso_filename']
+        config['input']['iso_url'] = "https://releases.ubuntu.com/"+ version + "/" +config['input']['iso_filename']
         config['input']['iso_url'] = "https://old-releases.ubuntu.com/releases/" + version + "/" + config['input']['iso_filename']
         config['input']['sha256_url'] = "https://old-releases.ubuntu.com/releases/" + version + "/" + config['input']['sha256_filename']
 elif config['os'] == "jammy":
-    version = 22.04
+    version = "22.04"
     minor_version = get_latest_minor_release(version)
     config['input'] = {}
-    config['input']['iso_filename'] = f"ubuntu-{version}.{minor_version}-live-server-amd64.iso"
-    config['input']['iso_url'] = "https://releases.ubuntu.com/22.04/" + config['input']['iso_filename']
+    config['input']['iso_filename'] = "ubuntu-" + version + "." + minor_version + "-live-server-amd64.iso"
+    config['input']['iso_url'] = "https://releases.ubuntu.com/"+ version + "/" +config['input']['iso_filename']
     config['input']['sha256_filename'] = "SHA256SUMS"
-    config['input']['sha256_url'] = "https://releases.ubuntu.com/22.04/SHA256SUMS"
+    config['input']['sha256_url'] = "https://releases.ubuntu.com/" + version + "/SHA256SUMS"
     config['packages'] = {}
     config['packages']['preinstall'] = [
         "python3-virtualenv",

--- a/container/build-iso.py
+++ b/container/build-iso.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import jinja2
 import requests
+import re
 from datetime import date
 import subprocess
 from pprint import pprint
@@ -58,10 +59,50 @@ with open("/config/config.yml", "r") as f:
 TMP_DIR = "iso"
 REQIREMENTS = ["7z", "gfxboot", "xorriso", "wget", "curl", "sha256sum"]
 
+def get_latest_minor_release(version):
+    url = f"https://releases.ubuntu.com/{version}/"
+    response = requests.get(url)
+    response.raise_for_status()
+
+    # Regex to match the minor release number in the ISO filename
+    match = re.search(rf"ubuntu-{version}\.(\d+)-live-server-amd64\.iso", response.text)
+
+    if match:
+        return match.group(1)
+
+    raise ValueError(f"Could not find a valid minor release for Ubuntu {version}.")
+
 # switch iso by selected os
-if config['os'] == "jammy":
+if config['os'] == "noble":
+    version = 24.04
+    minor_version = get_latest_minor_release(version)
     config['input'] = {}
-    config['input']['iso_filename'] = "ubuntu-22.04.3-live-server-amd64.iso"
+    config['input']['iso_filename'] = f"ubuntu-{version}.{minor_version}-live-server-amd64.iso"
+    config['input']['iso_url'] = "https://releases.ubuntu.com/24.04/" + config['input']['iso_filename']
+    config['input']['sha256_filename'] = "SHA256SUMS"
+    config['input']['sha256_url'] = "https://releases.ubuntu.com/24.04/SHA256SUMS"
+    config['packages'] = {}
+    config['packages']['preinstall'] = [
+        "python3-virtualenv",
+        "linux-generic-hwe-24.04",
+        "ubuntu-desktop",
+        "plymouth-theme-ubuntu-gnome-logo",
+        "ldap-utils",
+        "yad",
+    ]
+    #Test the URL, if 404 use old-releases.ubuntu.com
+    response = requests.get(config['input']['iso_url'])
+    if response.status_code == 404:
+        #extract figures in between first both dashes.
+        version = config['input']['iso_filename'].split("-")[1]
+        config['input']['iso_url'] = "https://releases.ubuntu.com/24.04/" + config['input']['iso_filename']
+        config['input']['iso_url'] = "https://old-releases.ubuntu.com/releases/" + version + "/" + config['input']['iso_filename']
+        config['input']['sha256_url'] = "https://old-releases.ubuntu.com/releases/" + version + "/" + config['input']['sha256_filename']
+elif config['os'] == "jammy":
+    version = 22.04
+    minor_version = get_latest_minor_release(version)
+    config['input'] = {}
+    config['input']['iso_filename'] = f"ubuntu-{version}.{minor_version}-live-server-amd64.iso"
     config['input']['iso_url'] = "https://releases.ubuntu.com/22.04/" + config['input']['iso_filename']
     config['input']['sha256_filename'] = "SHA256SUMS"
     config['input']['sha256_url'] = "https://releases.ubuntu.com/22.04/SHA256SUMS"
@@ -74,33 +115,10 @@ if config['os'] == "jammy":
         "ldap-utils",
         "yad",
     ]
-    #Test the URL, if 404 use old-releases.ubuntu.com
-    response = requests.get(config['input']['iso_url'])
-    if response.status_code == 404:
-        #extract figures in between first both dashes.
-        version = config['input']['iso_filename'].split("-")[1]
-        config['input']['iso_url'] = "https://releases.ubuntu.com/22.04/" + config['input']['iso_filename']
-        config['input']['iso_url'] = "https://old-releases.ubuntu.com/releases/" + version + "/" + config['input']['iso_filename']
-        config['input']['sha256_url'] = "https://old-releases.ubuntu.com/releases/" + version + "/" + config['input']['sha256_filename']
-elif config['os'] == "focal":
-    config['input'] = {}
-    config['input']['iso_filename'] = "ubuntu-20.04.6-live-server-amd64.iso"
-    config['input']['iso_url'] = "https://releases.ubuntu.com/20.04/" + config['input']['iso_filename'] 
-    config['input']['sha256_filename'] = "SHA256SUMS"
-    config['input']['sha256_url'] = "https://releases.ubuntu.com/20.04/SHA256SUMS"
-    config['packages'] = {}
-    config['packages']['preinstall'] = [
-        "linux-generic-hwe-20.04",
-        "ubuntu-desktop",
-        "plymouth-theme-ubuntu-logo",
-        "ldap-utils",
-        "yad",
-        "python3-virtualenv",
-    ]
 else:
     print("Invalid base os: %s"%(config['os']))
     print("Currently supported os are:")
-    print(" * Ubuntu: 'jammy', 'focal'")
+    print(" * Ubuntu: 'noble', 'jammy'")
     exit(1)
 
 ######

--- a/container/build-iso.py
+++ b/container/build-iso.py
@@ -202,6 +202,9 @@ shutil.copy("default-netplan.yml", os.path.join(TMP_DIR, "setup/default-netplan.
 # copy Gnome initial setup sudoers rule into iso
 shutil.copy("gnome-sudo", os.path.join(TMP_DIR, "setup/gnome-sudo"))
 
+# copy needrestart workaround into iso (https://discourse.ubuntu.com/t/needrestart-changes-in-ubuntu-24-04-service-restarts)
+shutil.copy("99needrestart", os.path.join(TMP_DIR, "setup/99needrestart"))
+
 # template autoinstall files
 os.mkdir(os.path.join(TMP_DIR, "nocloud-uefi"))
 with open(os.path.join(TMP_DIR, "nocloud-uefi/meta-data"), "w") as f:

--- a/container/change-keyboard-layout.j2
+++ b/container/change-keyboard-layout.j2
@@ -10,7 +10,7 @@ done)
 KEYBOARD_LAYOUT="$(yad --width 600 --height 600 --list --column 'Keyboard Layout' \
   --column '' ${ALLCOLS} \
   --print-column 1 --button gtk-ok \
-  --image /usr/share/icons/Adwaita/48x48/apps/accessories-character-map-symbolic.symbolic.png \
+  --image /setup/logo.png \
   --text 'Please select a keyboard layout')"
 
 KEYBOARD_LAYOUT=$(echo ${KEYBOARD_LAYOUT} | tr -d '|')

--- a/container/finish.sh.j2
+++ b/container/finish.sh.j2
@@ -52,7 +52,7 @@ cd "${ANSIBLE_WORKDIR}"
 
 virtualenv .
 source bin/activate
-pip3 install ansible-core==2.12.10
+pip3 install ansible-core==2.16
 
 {# Verbose ansible if develop #}
 ansible-playbook prepare.yml {% if config['specs']['ansible_vault_key_file'] != "" %}--vault-password-file=/etc/potos/ansible_vault_key {% endif %}{% if POTOS_ENV is defined and POTOS_ENV == 'develop' %}-vvv {% endif %}| sed -u 's/^/# /'

--- a/container/requirements.txt
+++ b/container/requirements.txt
@@ -1,2 +1,0 @@
-pyyaml
-Jinja2


### PR DESCRIPTION
## Description

* Add support for Ubuntu 24.04 (noble)
* Remove Ubuntu 20.04 support
* Add dynamic URL lookup feature (for minor releases)
* Adjust Github Action Image (replace Ubuntu 20.04 with 24.04)

Fixes # (issue)
* https://github.com/projectpotos/potos-iso-builder/issues/54
* https://github.com/projectpotos/potos-iso-builder/issues/55
* https://github.com/projectpotos/potos-iso-builder/issues/56

